### PR TITLE
Updated the code to work on newer versions of python (3.5+) fixes #1

### DIFF
--- a/wol.py
+++ b/wol.py
@@ -2,7 +2,7 @@
 #
 # Based on wol.py from http://code.activestate.com/recipes/358449-wake-on-lan/
 # Amended to use configuration file and hostnames
-# 
+#
 # Copyright (C) Fadly Tabrani, B Tasker
 #
 # Released under the PSF License See http://docs.python.org/2/license.html
@@ -14,7 +14,7 @@ import socket
 import struct
 import os
 import sys
-import ConfigParser
+import configparser
 
 
 myconfig = {}
@@ -38,20 +38,20 @@ def wake_on_lan(host):
         macaddress = macaddress.replace(sep, '')
     else:
         raise ValueError('Incorrect MAC address format')
- 
+
     # Pad the synchronization stream.
     data = ''.join(['FFFFFFFFFFFF', macaddress * 20])
-    send_data = '' 
+    send_data = b''
 
     # Split up the hex values and pack.
     for i in range(0, len(data), 2):
-        send_data = ''.join([send_data,
+        send_data = b''.join([send_data,
                              struct.pack('B', int(data[i: i + 2], 16))])
 
     # Broadcast it to the LAN.
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-    sock.sendto(send_data, (myconfig['General']['broadcast'], 7))
+    sock.sendto(send_data, (myconfig['General']['broadcast'], 4343))
     return True
 
 
@@ -61,7 +61,7 @@ def loadConfig():
 	"""
 	global mydir
 	global myconfig
-	Config = ConfigParser.ConfigParser()
+	Config = configparser.ConfigParser()
 	Config.read(mydir+"/.wol_config.ini")
 	sections = Config.sections()
 	dict1 = {}
@@ -79,31 +79,28 @@ def loadConfig():
 	return myconfig # Useful for testing
 
 def usage():
-	print 'Usage: wol.py [hostname]'
+	print('Usage: wol.py [hostname]')
 
 
 
 if __name__ == '__main__':
-    mydir = os.path.dirname(os.path.abspath(__file__))
-    conf = loadConfig()
-
-    try:
-    # Use macaddresses with any seperators.
-
-	if sys.argv[1] == 'list':
-		print 'Configured Hosts:'
-		for i in conf:
-			if i != 'General':
-				print '\t',i
-		print '\n'
-	else:
-
-		if not wake_on_lan(sys.argv[1]):
-			print 'Invalid Hostname specified'
-		else:
-			print 'Magic packet should be winging its way'
-    except:
-	usage()
+        mydir = os.path.dirname(os.path.abspath(__file__))
+        conf = loadConfig()
+        try:
+                # Use macaddresses with any seperators.
+                if sys.argv[1] == 'list':
+                        print('Configured Hosts:')
+                        for i in conf:
+                                if i != 'General':
+                                        print('\t',i)
+                        print('\n')
+                else:
+                        if not wake_on_lan(sys.argv[1]):
+                                print('Invalid Hostname specified')
+                        else:
+                                print('Magic packet should be winging its way')
+        except:
+                usage()
 
 
 

--- a/wol.py
+++ b/wol.py
@@ -51,7 +51,7 @@ def wake_on_lan(host):
     # Broadcast it to the LAN.
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-    sock.sendto(send_data, (myconfig['General']['broadcast'], 4343))
+    sock.sendto(send_data, (myconfig['General']['broadcast'], 7))
     return True
 
 


### PR DESCRIPTION
changes i made:

print is now required to be used as print('test') insted of print 'test'
and ConfigParser was changed to configparser

fixed some spacing/tab issues

and decleared bytes with b to avoid join problems (join expects string unless there is b before the calling string and should recive all parameters as bytes)

i tested those changes with python 3.5.2 (last updated Jun 25, 2016. )
