### PR TITLE
shebang fix.

### DIFF
--- a/wol.py
+++ b/wol.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Based on wol.py from http://code.activestate.com/recipes/358449-wake-on-lan/
 # Amended to use configuration file and hostnames


### PR DESCRIPTION
# !/usr/bin/env python calles python 2
# !/usr/bin/env python3 should be used insted

after testing it on my linux server i realised i forgot about this.
