### PR TITLE
Update MAC parsing with REGEX

### DIFF
--- a/wol.py
+++ b/wol.py
@@ -32,13 +32,13 @@ def wake_on_lan(host):
       return False
 
     # Check macaddress format and try to compensate.
-    if len(macaddress) == 12:
+    if re.match('([a-fA-F0-9]{2}){6}',macaddress):
         pass   
     else:
 	# Use regular expression to extract not usable chars
 	macaddress = re.sub('[^A-F0-9]', '', macaddress,flags=re.IGNORECASE)
 	# Re-check the value
-	if len(macaddress) == 12:
+	if re.match('([a-fA-F0-9]{2}){6}',macaddress):
             pass   
     	else:
             raise ValueError('Incorrect MAC address format')

--- a/wol.py
+++ b/wol.py
@@ -30,14 +30,16 @@ def wake_on_lan(host):
 
     except:
       return False
+
     #Get the mac numbers
-    numbers = re.findall('([a-fA-F0-9]{2})',macaddress)
-    #We must have 6 result, or the mac is invalid
+    numbers = re.findall('^([A-F0-9]{2}(([:][A-F0-9]{2}){5}|([-][A-F0-9]{2}){5})|([\s][A-F0-9]{2}){5})|([a-f0-9]{2}(([:][a-f0-9]{2}){5}|([-][a-f0-9]{2}){5}|([\s][a-f0-9]{2}){5}))$', macaddress)
+    #We must have 6 results, or the MAC is invalid
     if(len(numbers) == 6):
 	#If the result is correct, join it into a string
         macaddress= ''.join(numbers)
     else:
         raise ValueError('Incorrect MAC address format')
+	
     # Pad the synchronization stream.
     data = ''.join(['FFFFFFFFFFFF', macaddress * 20])
     send_data = b''

--- a/wol.py
+++ b/wol.py
@@ -15,6 +15,7 @@ import struct
 import os
 import sys
 import configparser
+import re
 
 
 myconfig = {}
@@ -32,12 +33,15 @@ def wake_on_lan(host):
 
     # Check macaddress format and try to compensate.
     if len(macaddress) == 12:
-        pass
-    elif len(macaddress) == 12 + 5:
-        sep = macaddress[2]
-        macaddress = macaddress.replace(sep, '')
+        pass   
     else:
-        raise ValueError('Incorrect MAC address format')
+	# Use regular expression to extract not usable chars
+	macaddress = re.sub('[^A-F0-9]', '', macaddress,flags=re.IGNORECASE)
+	# Re-check the value
+	if len(macaddress) == 12:
+            pass   
+    	else:
+            raise ValueError('Incorrect MAC address format')
 
     # Pad the synchronization stream.
     data = ''.join(['FFFFFFFFFFFF', macaddress * 20])

--- a/wol.py
+++ b/wol.py
@@ -37,8 +37,7 @@ def wake_on_lan(host):
 	#If the result is correct, join it into a string
         macaddress= ''.join(numbers)
     else:
-        raise ValueError('Incorrect MAC address format')  
-    
+        raise ValueError('Incorrect MAC address format')
     # Pad the synchronization stream.
     data = ''.join(['FFFFFFFFFFFF', macaddress * 20])
     send_data = b''

--- a/wol.py
+++ b/wol.py
@@ -30,19 +30,15 @@ def wake_on_lan(host):
 
     except:
       return False
-
-    # Check macaddress format and try to compensate.
-    if re.match('([a-fA-F0-9]{2}){6}',macaddress):
-        pass   
+    #Get the mac numbers
+    numbers = re.findall('([a-fA-F0-9]{2})',macaddress)
+    #We must have 6 result, or the mac is invalid
+    if(len(numbers) == 6):
+	#If the result is correct, join it into a string
+        macaddress= ''.join(numbers)
     else:
-	# Use regular expression to extract not usable chars
-	macaddress = re.sub('[^A-F0-9]', '', macaddress,flags=re.IGNORECASE)
-	# Re-check the value
-	if re.match('([a-fA-F0-9]{2}){6}',macaddress):
-            pass   
-    	else:
-            raise ValueError('Incorrect MAC address format')
-
+        raise ValueError('Incorrect MAC address format')  
+    
     # Pad the synchronization stream.
     data = ''.join(['FFFFFFFFFFFF', macaddress * 20])
     send_data = b''

--- a/wol.py
+++ b/wol.py
@@ -31,12 +31,12 @@ def wake_on_lan(host):
     except:
       return False
 
-    #Get the mac numbers
-    numbers = re.findall('^([A-F0-9]{2}(([:][A-F0-9]{2}){5}|([-][A-F0-9]{2}){5})|([\s][A-F0-9]{2}){5})|([a-f0-9]{2}(([:][a-f0-9]{2}){5}|([-][a-f0-9]{2}){5}|([\s][a-f0-9]{2}){5}))$', macaddress)
-    #We must have 6 results, or the MAC is invalid
-    if(len(numbers) == 6):
-	#If the result is correct, join it into a string
-        macaddress= ''.join(numbers)
+    # Check mac address format
+    found = re.fullmatch('^([A-F0-9]{2}(([:][A-F0-9]{2}){5}|([-][A-F0-9]{2}){5})|([\s][A-F0-9]{2}){5})|([a-f0-9]{2}(([:][a-f0-9]{2}){5}|([-][a-f0-9]{2}){5}|([\s][a-f0-9]{2}){5}))$', macaddress)
+    #We must found 1 match , or the MAC is invalid
+    if found:
+	#If the match is found, remove mac separator [:-\s]
+        macaddress = macaddress.replace(macaddress[2], '')
     else:
         raise ValueError('Incorrect MAC address format')
 	


### PR DESCRIPTION
The use of regular expressions for MAC parsing.

The following MAC expressions now are valid:

- `0A:14:22:01:23:7F`
- `0A-14-22-01-23-7F`
- `0A 14 22 01 23 7F`
- `0a:14:22:01:23:7f`
- `0a-14-22-01-23-7f`
- `0a 14 22 01 23 7f`

Take a look to the following PR for more info: https://github.com/RDCH106/Wake-On-Lan-Python/pull/1