### PR TITLE
Added auto conf creation dynamically and updated location

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,18 @@ Configuration File
 
 The configuration file is just a basic INI file, containing one section per host;
 
+The configuration file is located at `~/.config/bentasker.Wake-On-Lan-Python/wol_config.ini`
+
+The following is an example of hosts save in `wol_config.ini`
+
     [General]
     broadcast=192.168.1.255
-    
+
     [MyPc]
     mac=00:13:0d:e4:60:61
 
-    
-    
+
+
 License
 --------
 

--- a/wol.py
+++ b/wol.py
@@ -83,21 +83,19 @@ def loadConfig():
         Config['myPC'] = {'mac': '00:2a:a0:cf:83:15'}
         Config['myLaptop'] = {'mac': '00:13:0d:e4:60:61'}
         writeConfig(Config)     # Generate default conf file
-	Config.read(conf_path+"/wol_config.ini")
-	sections = Config.sections()
-	dict1 = {}
-	for section in sections:
-		options = Config.options(section)
+    Config.read(conf_path+"/wol_config.ini")
+    sections = Config.sections()
+    dict1 = {}
+    for section in sections:
+        options = Config.options(section)
 
-		sectkey = section
-		myconfig[sectkey] = {}
+        sectkey = section
+        myconfig[sectkey] = {}
 
+        for option in options:
+            myconfig[sectkey][option] = Config.get(section, option)
 
-		for option in options:
-			myconfig[sectkey][option] = Config.get(section,option)
-
-
-	return myconfig # Useful for testing
+    return myconfig     # Useful for testing
 
 def usage():
 	print('Usage: wol.py [hostname]')

--- a/wol.py
+++ b/wol.py
@@ -39,7 +39,7 @@ def wake_on_lan(host):
         macaddress = macaddress.replace(macaddress[2], '')
     else:
         raise ValueError('Incorrect MAC address format')
-	
+
     # Pad the synchronization stream.
     data = ''.join(['FFFFFFFFFFFF', macaddress * 20])
     send_data = b''
@@ -56,14 +56,34 @@ def wake_on_lan(host):
     return True
 
 
-def loadConfig():
-	""" Read in the Configuration file to get CDN specific settings
+def writeConfig(conf):
+    """ Write configuration file to save local settings """
+    global conf_path
+    conf.write(open(conf_path+'/wol_config.ini', 'w'))
 
-	"""
-	global mydir
-	global myconfig
-	Config = configparser.ConfigParser()
-	Config.read(mydir+"/.wol_config.ini")
+
+def loadConfig():
+    """ Read in the Configuration file to get CDN specific settings """
+    global conf_path
+    global myconfig
+    Config = configparser.ConfigParser()
+    # Create conf path if does not exists
+    if not os.path.exists(conf_path):
+        os.makedirs(conf_path, exist_ok=True)
+    # generate default config file if does not exists
+    if not os.path.exists(conf_path+'/wol_config.ini'):
+        # get broadcast ip dynamicly
+        local_ip = socket.gethostbyname(socket.gethostname())
+        local_ip = local_ip.rsplit('.', 1)
+        local_ip[1] = '255'
+        broadcast_ip = '.'.join(local_ip)
+        # Load default values to new conf file
+        Config['General'] = {'broadcast': broadcast_ip}
+        # two examples for devices
+        Config['myPC'] = {'mac': '00:2a:a0:cf:83:15'}
+        Config['myLaptop'] = {'mac': '00:13:0d:e4:60:61'}
+        writeConfig(Config)     # Generate default conf file
+	Config.read(conf_path+"/wol_config.ini")
 	sections = Config.sections()
 	dict1 = {}
 	for section in sections:
@@ -85,7 +105,7 @@ def usage():
 
 
 if __name__ == '__main__':
-        mydir = os.path.dirname(os.path.abspath(__file__))
+        conf_path = os.path.expanduser('~/.config/bentasker.Wake-On-Lan-Python')
         conf = loadConfig()
         try:
                 # Use macaddresses with any seperators.
@@ -102,7 +122,3 @@ if __name__ == '__main__':
                                 print('Magic packet should be winging its way')
         except:
                 usage()
-
-
-
-


### PR DESCRIPTION
Updated the config file location per XDG specs, its now set per user at ~/.config
Also took the time to auto generate a new config file if its missing (and its path) with default examples and a dynamic broadcast address based on the local network of the running host. 

please merge with no-ff for better branch topology.

resolves #7 