### PR TITLE
Feat: Dockerisation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:alpine
+
+# Set the config file location
+ENV WOL_CONFIG_DIR=/wol_config
+
+
+COPY wol.py /
+ENTRYPOINT ["/wol.py"]
+
+# Labels
+LABEL org.opencontainers.image.url=https://github.com/bentasker/Wake-On-Lan-Python/
+LABEL org.opencontainers.image.licenses=PSF-2.0
+LABEL org.opencontainers.image.title="Wake On LAN utility"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ Configuration File
 
 The configuration file is just a basic INI file, containing one section per host;
 
-The configuration file is located at `~/.config/bentasker.Wake-On-Lan-Python/wol_config.ini`
+By default, the configuration file is located at `~/.config/bentasker.Wake-On-Lan-Python/wol_config.ini`
+
+The location can be overridden via environment variable `WOL_CONFIG_DIR`:
+```
+export WOL_CONFIG_DIR="/some/path/wol_config
+```
+
+If it does not exist, it will be created and `wol_config.ini` created within it.
 
 The following is an example of hosts save in `wol_config.ini`
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,45 @@ or
     wol.py list
 
 
+Usage: Docker
+---------------
+
+It is also possible to run the utility with Docker, however there is a small additional configuration step required the first time that it's run
+
+Run `list`:
+```
+docker run \
+--rm \
+-v ~/.config/bentasker.Wake-On-Lan-Python/:/wol_config \
+bentasker12/wake-on-lan-python list
+```
+
+Edit the generated configuration file
+```
+vi ~/.config/bentasker.Wake-On-Lan-Python/wol_config.ini
+```
+
+You will find that the broadcast address is for the wrong network, replace this with the correct prefix
+```
+[General]
+broadcast = 172.0.1.255
+```
+
+becomes
+```
+[General]
+broadcast = 192.168.1.255
+```
+
+Subsequent runs should then run as desired
+```
+docker run \
+--rm \
+-v ~/.config/bentasker.Wake-On-Lan-Python/:/wol_config \
+bentasker12/wake-on-lan-python myPC
+```
+
+
 
 Configuration File
 --------------------

--- a/wol.py
+++ b/wol.py
@@ -9,6 +9,8 @@
 
 import typing as _t
 
+import os
+
 import inspect
 import re
 import socket
@@ -189,6 +191,13 @@ class WakeOnLan(object):
         )
 
     def __call__(self, *sys_args: str, load_config_from_file=True) -> None:
+        
+        # Allow the environment to override config dir location
+        env_config_dir = os.getenv("WOL_CONFIG_DIR", False)
+        if env_config_dir:
+            # Convert to an absolute path
+            self.__conf_dir = Path(env_config_dir).expanduser().absolute()
+        
         config = self.load_config() if load_config_from_file else self.config
 
         prompt = ("-p" in sys_args)


### PR DESCRIPTION
This PR provides a `Dockerfile` and makes supporting changes to `wol.py`/docs so that the utility can be run in Docker.

In *most* cases that's probably overkill, but having it available means that the utility can also potentially be triggered from things like Synology NAS's.